### PR TITLE
Add UI quick wins: breadcrumbs, empty states, skeletons, form sections

### DIFF
--- a/src/components/bom/BOMDetail.tsx
+++ b/src/components/bom/BOMDetail.tsx
@@ -6,6 +6,8 @@ import * as bomService from '../../services/bomService';
 import { BOM, BOMCostBreakdown } from '../../types/BOM';
 import { useAlert } from '../../contexts/AlertContext';
 import ConfirmModal from '../common/ConfirmModal';
+import Breadcrumbs from '../common/Breadcrumbs';
+import { SkeletonDetailPage } from '../common/Skeleton';
 
 export default function BOMDetail() {
   const { id } = useParams<{ id: string }>();
@@ -56,13 +58,20 @@ export default function BOMDetail() {
   };
 
   if (!bom || !breakdown) {
-    return <div>Loading...</div>;
+    return <SkeletonDetailPage />;
   }
 
   const availability = bomService.checkAvailability(bom.id);
 
+  const breadcrumbItems = [
+    { label: 'Bill of Materials', path: '/bom' },
+    { label: bom.name },
+  ];
+
   return (
-    <Card>
+    <>
+      <Breadcrumbs items={breadcrumbItems} />
+      <Card>
       <Card.Header className="d-flex justify-content-between align-items-center">
         <h4 className="mb-0">{bom.name}</h4>
         <Badge bg={availability.canBuild ? 'success' : 'warning'}>
@@ -178,28 +187,29 @@ export default function BOMDetail() {
 
         <ButtonGroup>
           <Link to={`/bom/${bom.id}/edit`} className="btn btn-primary">
-            <FaEdit className="me-1" /> Edit
+            <FaEdit className="me-1" aria-hidden="true" /> Edit
           </Link>
-          <Button variant="secondary" onClick={handleDuplicate}>
-            <FaCopy className="me-1" /> Duplicate
+          <Button variant="secondary" onClick={handleDuplicate} aria-label="Duplicate BOM">
+            <FaCopy className="me-1" aria-hidden="true" /> Duplicate
           </Button>
-          <Button variant="warning" onClick={() => setShowDeleteModal(true)}>
-            <FaTrash className="me-1" /> Delete
+          <Button variant="danger" onClick={() => setShowDeleteModal(true)} aria-label="Delete BOM">
+            <FaTrash className="me-1" aria-hidden="true" /> Delete
           </Button>
-          <Button variant="danger" onClick={() => navigate('/bom')}>
+          <Button variant="outline-secondary" onClick={() => navigate('/bom')}>
             Back to List
           </Button>
         </ButtonGroup>
       </Card.Body>
 
-      <ConfirmModal
-        show={showDeleteModal}
-        title="Delete BOM"
-        message={`Are you sure you want to delete "${bom.name}"?`}
-        confirmLabel="Delete"
-        onConfirm={handleDelete}
-        onCancel={() => setShowDeleteModal(false)}
-      />
-    </Card>
+        <ConfirmModal
+          show={showDeleteModal}
+          title="Delete BOM"
+          message={`Are you sure you want to delete "${bom.name}"?`}
+          confirmLabel="Delete"
+          onConfirm={handleDelete}
+          onCancel={() => setShowDeleteModal(false)}
+        />
+      </Card>
+    </>
   );
 }

--- a/src/components/bom/BOMForm.tsx
+++ b/src/components/bom/BOMForm.tsx
@@ -7,6 +7,7 @@ import * as itemService from '../../services/itemService';
 import { BOMFormData, BOMItem } from '../../types/BOM';
 import { Item } from '../../types/Item';
 import { useAlert } from '../../contexts/AlertContext';
+import Breadcrumbs from '../common/Breadcrumbs';
 
 export default function BOMForm() {
   const { id } = useParams<{ id: string }>();
@@ -147,11 +148,24 @@ export default function BOMForm() {
     (item) => !formData.items.some((bi) => bi.itemId === item.id)
   );
 
+  const breadcrumbItems = isEditing
+    ? [
+        { label: 'Bill of Materials', path: '/bom' },
+        { label: formData.name || 'Edit BOM', path: `/bom/${id}` },
+        { label: 'Edit' },
+      ]
+    : [
+        { label: 'Bill of Materials', path: '/bom' },
+        { label: 'New BOM' },
+      ];
+
   return (
-    <Card>
-      <Card.Header>
-        <h4 className="mb-0">{isEditing ? 'Edit BOM' : 'New BOM'}</h4>
-      </Card.Header>
+    <>
+      <Breadcrumbs items={breadcrumbItems} />
+      <Card>
+        <Card.Header>
+          <h4 className="mb-0">{isEditing ? 'Edit BOM' : 'New BOM'}</h4>
+        </Card.Header>
       <Card.Body>
         <Form onSubmit={handleSubmit}>
           <Row className="mb-3">
@@ -266,8 +280,9 @@ export default function BOMForm() {
                         variant="outline-danger"
                         size="sm"
                         onClick={() => handleRemoveItem(bomItem.itemId)}
+                        aria-label={`Remove ${getItemName(bomItem.itemId)}`}
                       >
-                        <FaTrash />
+                        <FaTrash aria-hidden="true" />
                       </Button>
                     </td>
                   </tr>
@@ -295,12 +310,13 @@ export default function BOMForm() {
             <Button variant="primary" type="submit">
               {isEditing ? 'Update BOM' : 'Create BOM'}
             </Button>
-            <Button variant="danger" onClick={() => navigate('/bom')}>
+            <Button variant="secondary" onClick={() => navigate('/bom')}>
               Cancel
             </Button>
           </ButtonGroup>
         </Form>
       </Card.Body>
-    </Card>
+      </Card>
+    </>
   );
 }

--- a/src/components/bom/BOMList.tsx
+++ b/src/components/bom/BOMList.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, Table, Button, Badge } from 'react-bootstrap';
-import { FaPlus, FaEye, FaEdit, FaTrash } from 'react-icons/fa';
+import { FaPlus, FaEye, FaEdit, FaTrash, FaClipboardList } from 'react-icons/fa';
 import * as bomService from '../../services/bomService';
 import { BOM } from '../../types/BOM';
 import { useAlert } from '../../contexts/AlertContext';
 import ConfirmModal from '../common/ConfirmModal';
+import EmptyState from '../common/EmptyState';
 
 export default function BOMList() {
   const [boms, setBoms] = useState<BOM[]>([]);
@@ -56,9 +57,13 @@ export default function BOMList() {
       </Card.Header>
       <Card.Body>
         {boms.length === 0 ? (
-          <p className="text-muted text-center py-4">
-            No BOMs created yet. Create your first BOM to group items into projects.
-          </p>
+          <EmptyState
+            icon={FaClipboardList}
+            title="No BOMs created yet"
+            description="Create your first Bill of Materials to group items into projects."
+            actionLabel="Create First BOM"
+            actionPath="/bom/new"
+          />
         ) : (
           <Table striped hover responsive>
             <thead>
@@ -83,18 +88,27 @@ export default function BOMList() {
                   <td>{new Date(bom.createdAt).toLocaleDateString()}</td>
                   <td>
                     <div className="d-flex gap-1">
-                      <Link to={`/bom/${bom.id}`} className="btn btn-sm btn-outline-primary">
-                        <FaEye />
+                      <Link
+                        to={`/bom/${bom.id}`}
+                        className="btn btn-sm btn-outline-primary"
+                        aria-label={`View ${bom.name}`}
+                      >
+                        <FaEye aria-hidden="true" />
                       </Link>
-                      <Link to={`/bom/${bom.id}/edit`} className="btn btn-sm btn-outline-secondary">
-                        <FaEdit />
+                      <Link
+                        to={`/bom/${bom.id}/edit`}
+                        className="btn btn-sm btn-outline-secondary"
+                        aria-label={`Edit ${bom.name}`}
+                      >
+                        <FaEdit aria-hidden="true" />
                       </Link>
                       <Button
                         variant="outline-danger"
                         size="sm"
                         onClick={() => setDeleteTarget(bom)}
+                        aria-label={`Delete ${bom.name}`}
                       >
-                        <FaTrash />
+                        <FaTrash aria-hidden="true" />
                       </Button>
                     </div>
                   </td>

--- a/src/components/common/Breadcrumbs.tsx
+++ b/src/components/common/Breadcrumbs.tsx
@@ -1,0 +1,36 @@
+import { Link } from 'react-router-dom';
+import { Breadcrumb } from 'react-bootstrap';
+import { FaHome } from 'react-icons/fa';
+
+export interface BreadcrumbItem {
+  label: string;
+  path?: string;
+}
+
+interface BreadcrumbsProps {
+  items: BreadcrumbItem[];
+}
+
+export default function Breadcrumbs({ items }: BreadcrumbsProps) {
+  return (
+    <Breadcrumb className="mb-3">
+      <Breadcrumb.Item linkAs={Link} linkProps={{ to: '/' }}>
+        <FaHome className="me-1" aria-hidden="true" />
+        <span className="visually-hidden">Home</span>
+      </Breadcrumb.Item>
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+        return (
+          <Breadcrumb.Item
+            key={index}
+            active={isLast}
+            linkAs={!isLast && item.path ? Link : undefined}
+            linkProps={!isLast && item.path ? { to: item.path } : undefined}
+          >
+            {item.label}
+          </Breadcrumb.Item>
+        );
+      })}
+    </Breadcrumb>
+  );
+}

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,0 +1,40 @@
+import { Link } from 'react-router-dom';
+import { Button } from 'react-bootstrap';
+import { IconType } from 'react-icons';
+import { FaBoxOpen } from 'react-icons/fa';
+
+interface EmptyStateProps {
+  icon?: IconType;
+  title: string;
+  description?: string;
+  actionLabel?: string;
+  actionPath?: string;
+  onAction?: () => void;
+}
+
+export default function EmptyState({
+  icon: Icon = FaBoxOpen,
+  title,
+  description,
+  actionLabel,
+  actionPath,
+  onAction,
+}: EmptyStateProps) {
+  return (
+    <div className="text-center py-5">
+      <Icon size={48} className="text-muted mb-3" aria-hidden="true" />
+      <h5 className="text-muted">{title}</h5>
+      {description && <p className="text-muted mb-4">{description}</p>}
+      {actionLabel && actionPath && (
+        <Link to={actionPath} className="btn btn-primary">
+          {actionLabel}
+        </Link>
+      )}
+      {actionLabel && onAction && !actionPath && (
+        <Button variant="primary" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/Skeleton.css
+++ b/src/components/common/Skeleton.css
@@ -1,0 +1,72 @@
+.skeleton {
+  display: inline-block;
+  background: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.5s infinite;
+  border-radius: 4px;
+}
+
+.skeleton-text {
+  width: 100%;
+  height: 1em;
+  margin-bottom: 0.5em;
+}
+
+.skeleton-rectangular {
+  width: 100%;
+  height: 100px;
+}
+
+.skeleton-circular {
+  border-radius: 50%;
+}
+
+.skeleton-table {
+  padding: 1rem;
+}
+
+.skeleton-table-header {
+  display: flex;
+  gap: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid #dee2e6;
+  margin-bottom: 0.5rem;
+}
+
+.skeleton-table-header .skeleton {
+  flex: 1;
+}
+
+.skeleton-table-row {
+  display: flex;
+  gap: 1rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.skeleton-table-row .skeleton {
+  flex: 1;
+}
+
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Dark mode support */
+[data-bs-theme="dark"] .skeleton {
+  background: linear-gradient(90deg, #374151 25%, #4b5563 50%, #374151 75%);
+  background-size: 200% 100%;
+}
+
+[data-bs-theme="dark"] .skeleton-table-header {
+  border-bottom-color: #4b5563;
+}
+
+[data-bs-theme="dark"] .skeleton-table-row {
+  border-bottom-color: #374151;
+}

--- a/src/components/common/Skeleton.tsx
+++ b/src/components/common/Skeleton.tsx
@@ -1,0 +1,105 @@
+import './Skeleton.css';
+
+interface SkeletonProps {
+  variant?: 'text' | 'rectangular' | 'circular';
+  width?: string | number;
+  height?: string | number;
+  className?: string;
+  count?: number;
+}
+
+export default function Skeleton({
+  variant = 'text',
+  width,
+  height,
+  className = '',
+  count = 1,
+}: SkeletonProps) {
+  const style: React.CSSProperties = {
+    width: typeof width === 'number' ? `${width}px` : width,
+    height: typeof height === 'number' ? `${height}px` : height,
+  };
+
+  const elements = Array.from({ length: count }, (_, index) => (
+    <span
+      key={index}
+      className={`skeleton skeleton-${variant} ${className}`}
+      style={style}
+      aria-hidden="true"
+    />
+  ));
+
+  return <>{elements}</>;
+}
+
+interface SkeletonTableProps {
+  rows?: number;
+  columns?: number;
+}
+
+export function SkeletonTable({ rows = 5, columns = 6 }: SkeletonTableProps) {
+  return (
+    <div className="skeleton-table" role="status" aria-label="Loading data">
+      <div className="skeleton-table-header">
+        {Array.from({ length: columns }, (_, i) => (
+          <Skeleton key={i} variant="text" height={20} />
+        ))}
+      </div>
+      {Array.from({ length: rows }, (_, rowIndex) => (
+        <div key={rowIndex} className="skeleton-table-row">
+          {Array.from({ length: columns }, (_, colIndex) => (
+            <Skeleton key={colIndex} variant="text" height={16} />
+          ))}
+        </div>
+      ))}
+      <span className="visually-hidden">Loading...</span>
+    </div>
+  );
+}
+
+export function SkeletonCard() {
+  return (
+    <div className="card" role="status" aria-label="Loading content">
+      <div className="card-header">
+        <Skeleton variant="text" width="40%" height={24} />
+      </div>
+      <div className="card-body">
+        <Skeleton variant="text" width="100%" height={16} className="mb-2" />
+        <Skeleton variant="text" width="100%" height={16} className="mb-2" />
+        <Skeleton variant="text" width="80%" height={16} className="mb-3" />
+        <Skeleton variant="text" width="60%" height={16} className="mb-2" />
+        <Skeleton variant="text" width="70%" height={16} className="mb-2" />
+        <Skeleton variant="text" width="50%" height={16} />
+      </div>
+      <span className="visually-hidden">Loading...</span>
+    </div>
+  );
+}
+
+export function SkeletonDetailPage() {
+  return (
+    <div className="card" role="status" aria-label="Loading item details">
+      <div className="card-header">
+        <Skeleton variant="text" width="50%" height={28} />
+      </div>
+      <div className="card-body">
+        <div className="row mb-4">
+          <div className="col-md-12">
+            <Skeleton variant="rectangular" width="65%" height={200} className="mb-3" />
+          </div>
+        </div>
+        {Array.from({ length: 8 }, (_, i) => (
+          <div key={i} className="row mb-2">
+            <div className="col-md-3">
+              <Skeleton variant="text" width="80%" height={16} />
+            </div>
+            <div className="col-md-9">
+              <Skeleton variant="text" width="60%" height={16} />
+            </div>
+          </div>
+        ))}
+      </div>
+      <span className="visually-hidden">Loading...</span>
+    </div>
+  );
+}

--- a/src/components/items/ItemDetail.tsx
+++ b/src/components/items/ItemDetail.tsx
@@ -8,6 +8,8 @@ import { VendorPriceResult } from '../../types/Vendor';
 import { useAlert } from '../../contexts/AlertContext';
 import ConfirmModal from '../common/ConfirmModal';
 import CostHistoryChart from './CostHistoryChart';
+import Breadcrumbs from '../common/Breadcrumbs';
+import { SkeletonDetailPage } from '../common/Skeleton';
 
 export default function ItemDetail() {
   const { id } = useParams<{ id: string }>();
@@ -62,14 +64,21 @@ export default function ItemDetail() {
   };
 
   if (!item) {
-    return <div>Loading...</div>;
+    return <SkeletonDetailPage />;
   }
 
+  const breadcrumbItems = [
+    { label: 'Inventory', path: '/items' },
+    { label: item.name },
+  ];
+
   return (
-    <Card>
-      <Card.Header>
-        <h4 className="mb-0">{item.name}</h4>
-      </Card.Header>
+    <>
+      <Breadcrumbs items={breadcrumbItems} />
+      <Card>
+        <Card.Header>
+          <h4 className="mb-0">{item.name}</h4>
+        </Card.Header>
       <Card.Body>
         {item.picture && (
           <Row className="mb-4">
@@ -243,23 +252,24 @@ export default function ItemDetail() {
           <Link to={`/items/${item.id}/edit`} className="btn btn-primary">
             Edit
           </Link>
-          <Button variant="warning" onClick={() => setShowDeleteModal(true)}>
+          <Button variant="danger" onClick={() => setShowDeleteModal(true)}>
             Delete
           </Button>
-          <Button variant="danger" onClick={() => navigate('/items')}>
-            Cancel
+          <Button variant="secondary" onClick={() => navigate('/items')}>
+            Back to List
           </Button>
         </ButtonGroup>
       </Card.Body>
 
-      <ConfirmModal
-        show={showDeleteModal}
-        title="Delete Item"
-        message={`Are you sure you want to delete "${item.name}"?`}
-        confirmLabel="Delete"
-        onConfirm={handleDelete}
-        onCancel={() => setShowDeleteModal(false)}
-      />
-    </Card>
+        <ConfirmModal
+          show={showDeleteModal}
+          title="Delete Item"
+          message={`Are you sure you want to delete "${item.name}"?`}
+          confirmLabel="Delete"
+          onConfirm={handleDelete}
+          onCancel={() => setShowDeleteModal(false)}
+        />
+      </Card>
+    </>
   );
 }

--- a/src/components/items/ItemForm.tsx
+++ b/src/components/items/ItemForm.tsx
@@ -8,6 +8,7 @@ import { ItemFormData, CATEGORIES } from '../../types/Item';
 import { ItemTemplate } from '../../types/ItemTemplate';
 import { useAlert } from '../../contexts/AlertContext';
 import { compressImage, formatBytes, compressionPercent } from '../../utils/imageOptimizer';
+import Breadcrumbs from '../common/Breadcrumbs';
 
 export default function ItemForm() {
   const { id } = useParams<{ id: string }>();
@@ -188,15 +189,28 @@ export default function ItemForm() {
     }
   };
 
+  const breadcrumbItems = isEditing
+    ? [
+        { label: 'Inventory', path: '/items' },
+        { label: formData.name || 'Edit Item', path: `/items/${id}` },
+        { label: 'Edit' },
+      ]
+    : [
+        { label: 'Inventory', path: '/items' },
+        { label: 'New Item' },
+      ];
+
   return (
-    <Card>
-      <Card.Header>
-        <h4 className="mb-0">{isEditing ? 'Edit Item' : 'New Item'}</h4>
-      </Card.Header>
+    <>
+      <Breadcrumbs items={breadcrumbItems} />
+      <Card>
+        <Card.Header>
+          <h4 className="mb-0">{isEditing ? 'Edit Item' : 'New Item'}</h4>
+        </Card.Header>
       <Card.Body>
         <Form onSubmit={handleSubmit}>
           {!isEditing && templates.length > 0 && (
-            <Row className="mb-3">
+            <Row className="mb-4">
               <Form.Label column sm={3}>Use Template</Form.Label>
               <Col sm={5}>
                 <Form.Select onChange={handleTemplateSelect} defaultValue="">
@@ -211,227 +225,247 @@ export default function ItemForm() {
             </Row>
           )}
 
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Name</Form.Label>
-            <Col sm={5}>
-              <Form.Control
-                type="text"
-                name="name"
-                value={formData.name}
-                onChange={handleChange}
-                required
-              />
-            </Col>
-          </Row>
-
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Description</Form.Label>
-            <Col sm={5}>
-              <Form.Control
-                as="textarea"
-                rows={10}
-                name="description"
-                value={formData.description}
-                onChange={handleChange}
-              />
-            </Col>
-          </Row>
-
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Product Model Number</Form.Label>
-            <Col sm={5}>
-              <Form.Control
-                type="text"
-                name="productModelNumber"
-                value={formData.productModelNumber}
-                onChange={handleChange}
-              />
-            </Col>
-          </Row>
-
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Vendor Name</Form.Label>
-            <Col sm={5}>
-              <Form.Control
-                type="text"
-                name="vendorName"
-                value={formData.vendorName}
-                onChange={handleChange}
-              />
-            </Col>
-          </Row>
-
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Vendor Part Number</Form.Label>
-            <Col sm={5}>
-              <div className="d-flex gap-2">
+          {/* Basic Information Section */}
+          <fieldset className="mb-4">
+            <legend className="h6 text-muted border-bottom pb-2 mb-3">Basic Information</legend>
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Name <span className="text-danger">*</span></Form.Label>
+              <Col sm={5}>
                 <Form.Control
                   type="text"
-                  name="vendorPartNumber"
-                  value={formData.vendorPartNumber}
+                  name="name"
+                  value={formData.name}
+                  onChange={handleChange}
+                  required
+                />
+              </Col>
+            </Row>
+
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Description</Form.Label>
+              <Col sm={5}>
+                <Form.Control
+                  as="textarea"
+                  rows={5}
+                  name="description"
+                  value={formData.description}
                   onChange={handleChange}
                 />
-                <Button
-                  variant="outline-secondary"
-                  onClick={handleVendorLookup}
-                  disabled={isLookingUpPrice || !formData.vendorName || !formData.vendorPartNumber}
-                  title="Look up price from vendor"
+              </Col>
+            </Row>
+
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Category</Form.Label>
+              <Col sm={5}>
+                <Form.Select
+                  name="category"
+                  value={formData.category}
+                  onChange={handleChange}
                 >
-                  {isLookingUpPrice ? <Spinner size="sm" animation="border" /> : 'Lookup'}
-                </Button>
-              </div>
-              <Form.Text className="text-muted">
-                Enter vendor name and part number, then click Lookup for pricing
-              </Form.Text>
-            </Col>
-          </Row>
+                  {CATEGORIES.map((cat) => (
+                    <option key={cat} value={cat}>
+                      {cat}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Col>
+            </Row>
 
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Quantity</Form.Label>
-            <Col sm={5}>
-              <Form.Control
-                type="number"
-                name="quantity"
-                value={formData.quantity}
-                onChange={handleChange}
-                min={0}
-              />
-            </Col>
-          </Row>
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Product Model Number</Form.Label>
+              <Col sm={5}>
+                <Form.Control
+                  type="text"
+                  name="productModelNumber"
+                  value={formData.productModelNumber}
+                  onChange={handleChange}
+                />
+              </Col>
+            </Row>
+          </fieldset>
 
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Vendor URL</Form.Label>
-            <Col sm={5}>
-              <Form.Control
-                type="url"
-                name="vendorUrl"
-                value={formData.vendorUrl}
-                onChange={handleChange}
-              />
-            </Col>
-          </Row>
+          {/* Vendor Information Section */}
+          <fieldset className="mb-4">
+            <legend className="h6 text-muted border-bottom pb-2 mb-3">Vendor Information</legend>
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Vendor Name</Form.Label>
+              <Col sm={5}>
+                <Form.Control
+                  type="text"
+                  name="vendorName"
+                  value={formData.vendorName}
+                  onChange={handleChange}
+                />
+              </Col>
+            </Row>
 
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Location</Form.Label>
-            <Col sm={5}>
-              <Form.Control
-                type="text"
-                name="location"
-                value={formData.location}
-                onChange={handleChange}
-              />
-            </Col>
-          </Row>
-
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Barcode</Form.Label>
-            <Col sm={5}>
-              <Form.Control
-                type="text"
-                name="barcode"
-                value={formData.barcode}
-                onChange={handleChange}
-                placeholder="e.g., RIMS-0001 or UPC"
-              />
-            </Col>
-          </Row>
-
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Reorder Point</Form.Label>
-            <Col sm={5}>
-              <Form.Control
-                type="number"
-                name="reorderPoint"
-                value={formData.reorderPoint}
-                onChange={handleChange}
-                min={0}
-              />
-              <Form.Text className="text-muted">
-                Alert when quantity falls to or below this level
-              </Form.Text>
-            </Col>
-          </Row>
-
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Unit Value ($)</Form.Label>
-            <Col sm={5}>
-              <Form.Control
-                type="number"
-                name="unitValue"
-                value={formData.unitValue}
-                onChange={handleChange}
-                min={0}
-                step={0.01}
-              />
-            </Col>
-          </Row>
-
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Category</Form.Label>
-            <Col sm={5}>
-              <Form.Select
-                name="category"
-                value={formData.category}
-                onChange={handleChange}
-              >
-                {CATEGORIES.map((cat) => (
-                  <option key={cat} value={cat}>
-                    {cat}
-                  </option>
-                ))}
-              </Form.Select>
-            </Col>
-          </Row>
-
-          <Row className="mb-3">
-            <Form.Label column sm={3}>Picture</Form.Label>
-            <Col sm={5}>
-              <Form.Control
-                type="file"
-                accept="image/*"
-                onChange={handleImageChange}
-                disabled={isCompressing}
-              />
-              {isCompressing && (
-                <div className="mt-2">
-                  <Spinner size="sm" animation="border" className="me-2" />
-                  Compressing image...
-                </div>
-              )}
-              {previewImage && !isCompressing && (
-                <div className="mt-2">
-                  <img
-                    src={previewImage}
-                    alt="Preview"
-                    style={{ maxWidth: '250px', maxHeight: '200px' }}
-                    className="img-thumbnail"
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Vendor Part Number</Form.Label>
+              <Col sm={5}>
+                <div className="d-flex gap-2">
+                  <Form.Control
+                    type="text"
+                    name="vendorPartNumber"
+                    value={formData.vendorPartNumber}
+                    onChange={handleChange}
                   />
                   <Button
-                    variant="outline-danger"
-                    size="sm"
-                    className="ms-2"
-                    onClick={handleRemoveImage}
+                    variant="outline-secondary"
+                    onClick={handleVendorLookup}
+                    disabled={isLookingUpPrice || !formData.vendorName || !formData.vendorPartNumber}
+                    title="Look up price from vendor"
+                    aria-label="Look up vendor price"
                   >
-                    Remove
+                    {isLookingUpPrice ? <Spinner size="sm" animation="border" /> : 'Lookup'}
                   </Button>
-                  {imageCompression && (
-                    <div className="mt-1">
-                      {imageCompression.wasCompressed ? (
-                        <Badge bg="success">
-                          Compressed: {formatBytes(imageCompression.originalSize)} → {formatBytes(imageCompression.compressedSize)}
-                          ({compressionPercent(imageCompression.originalSize, imageCompression.compressedSize)}% saved)
-                        </Badge>
-                      ) : (
-                        <Badge bg="secondary">
-                          Size: {formatBytes(imageCompression.originalSize)} (no compression needed)
-                        </Badge>
-                      )}
-                    </div>
-                  )}
                 </div>
-              )}
-            </Col>
-          </Row>
+                <Form.Text className="text-muted">
+                  Enter vendor name and part number, then click Lookup for pricing
+                </Form.Text>
+              </Col>
+            </Row>
+
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Vendor URL</Form.Label>
+              <Col sm={5}>
+                <Form.Control
+                  type="url"
+                  name="vendorUrl"
+                  value={formData.vendorUrl}
+                  onChange={handleChange}
+                  placeholder="https://..."
+                />
+              </Col>
+            </Row>
+          </fieldset>
+
+          {/* Inventory Details Section */}
+          <fieldset className="mb-4">
+            <legend className="h6 text-muted border-bottom pb-2 mb-3">Inventory Details</legend>
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Quantity</Form.Label>
+              <Col sm={5}>
+                <Form.Control
+                  type="number"
+                  name="quantity"
+                  value={formData.quantity}
+                  onChange={handleChange}
+                  min={0}
+                />
+              </Col>
+            </Row>
+
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Unit Value ($)</Form.Label>
+              <Col sm={5}>
+                <Form.Control
+                  type="number"
+                  name="unitValue"
+                  value={formData.unitValue}
+                  onChange={handleChange}
+                  min={0}
+                  step={0.01}
+                />
+              </Col>
+            </Row>
+
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Location</Form.Label>
+              <Col sm={5}>
+                <Form.Control
+                  type="text"
+                  name="location"
+                  value={formData.location}
+                  onChange={handleChange}
+                  placeholder="e.g., Shelf A3, Bin 12"
+                />
+              </Col>
+            </Row>
+
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Barcode</Form.Label>
+              <Col sm={5}>
+                <Form.Control
+                  type="text"
+                  name="barcode"
+                  value={formData.barcode}
+                  onChange={handleChange}
+                  placeholder="e.g., RIMS-0001 or UPC"
+                />
+              </Col>
+            </Row>
+
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Reorder Point</Form.Label>
+              <Col sm={5}>
+                <Form.Control
+                  type="number"
+                  name="reorderPoint"
+                  value={formData.reorderPoint}
+                  onChange={handleChange}
+                  min={0}
+                />
+                <Form.Text className="text-muted">
+                  Alert when quantity falls to or below this level
+                </Form.Text>
+              </Col>
+            </Row>
+          </fieldset>
+
+          {/* Media Section */}
+          <fieldset className="mb-4">
+            <legend className="h6 text-muted border-bottom pb-2 mb-3">Media</legend>
+            <Row className="mb-3">
+              <Form.Label column sm={3}>Picture</Form.Label>
+              <Col sm={5}>
+                <Form.Control
+                  type="file"
+                  accept="image/*"
+                  onChange={handleImageChange}
+                  disabled={isCompressing}
+                />
+                {isCompressing && (
+                  <div className="mt-2">
+                    <Spinner size="sm" animation="border" className="me-2" />
+                    Compressing image...
+                  </div>
+                )}
+                {previewImage && !isCompressing && (
+                  <div className="mt-2">
+                    <img
+                      src={previewImage}
+                      alt="Preview"
+                      style={{ maxWidth: '250px', maxHeight: '200px' }}
+                      className="img-thumbnail"
+                    />
+                    <Button
+                      variant="outline-danger"
+                      size="sm"
+                      className="ms-2"
+                      onClick={handleRemoveImage}
+                      aria-label="Remove image"
+                    >
+                      Remove
+                    </Button>
+                    {imageCompression && (
+                      <div className="mt-1">
+                        {imageCompression.wasCompressed ? (
+                          <Badge bg="success">
+                            Compressed: {formatBytes(imageCompression.originalSize)} → {formatBytes(imageCompression.compressedSize)}
+                            ({compressionPercent(imageCompression.originalSize, imageCompression.compressedSize)}% saved)
+                          </Badge>
+                        ) : (
+                          <Badge bg="secondary">
+                            Size: {formatBytes(imageCompression.originalSize)} (no compression needed)
+                          </Badge>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </Col>
+            </Row>
+          </fieldset>
 
           <Row>
             <Col sm={{ span: 5, offset: 3 }}>
@@ -439,7 +473,7 @@ export default function ItemForm() {
                 <Button variant="primary" type="submit">
                   {isEditing ? 'Update Item' : 'Create Item'}
                 </Button>
-                <Button variant="danger" onClick={() => navigate('/items')}>
+                <Button variant="secondary" onClick={() => navigate('/items')}>
                   Cancel
                 </Button>
               </ButtonGroup>
@@ -447,6 +481,7 @@ export default function ItemForm() {
           </Row>
         </Form>
       </Card.Body>
-    </Card>
+      </Card>
+    </>
   );
 }

--- a/src/components/items/ItemList.tsx
+++ b/src/components/items/ItemList.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, Table, Button, Form, ButtonGroup } from 'react-bootstrap';
-import { FaEdit, FaTrash, FaFileExcel, FaFilePdf } from 'react-icons/fa';
+import { FaEdit, FaTrash, FaFileExcel, FaFilePdf, FaBoxOpen } from 'react-icons/fa';
 import * as itemService from '../../services/itemService';
 import { Item } from '../../types/Item';
 import { useAlert } from '../../contexts/AlertContext';
@@ -10,6 +10,7 @@ import ConfirmModal from '../common/ConfirmModal';
 import ItemFilters from './ItemFilters';
 import BulkActions from './BulkActions';
 import LowStockAlert from '../common/LowStockAlert';
+import EmptyState from '../common/EmptyState';
 import { exportToCSV, exportToPDF } from '../../utils/export';
 import { formatCurrency } from '../../utils/formatters';
 import { ITEMS_PER_PAGE, LOW_STOCK_THRESHOLD } from '../../constants/config';
@@ -338,15 +339,20 @@ export default function ItemList() {
                 <td className="text-center">{item.location}</td>
                 <td className="text-center">{item.category}</td>
                 <td className="text-center">
-                  <Link to={`/items/${item.id}/edit`} className="btn btn-sm btn-outline-primary me-1">
-                    <FaEdit />
+                  <Link
+                    to={`/items/${item.id}/edit`}
+                    className="btn btn-sm btn-outline-primary me-1"
+                    aria-label={`Edit ${item.name}`}
+                  >
+                    <FaEdit aria-hidden="true" />
                   </Link>
                   <Button
                     variant="outline-danger"
                     size="sm"
                     onClick={() => setDeleteModalItem(item)}
+                    aria-label={`Delete ${item.name}`}
                   >
-                    <FaTrash />
+                    <FaTrash aria-hidden="true" />
                   </Button>
                 </td>
               </tr>
@@ -364,13 +370,31 @@ export default function ItemList() {
           </tfoot>
         </Table>
 
-        <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={setCurrentPage}
-          totalItems={filteredItems.length}
-          itemsPerPage={ITEMS_PER_PAGE}
-        />
+        {items.length === 0 ? (
+          <EmptyState
+            icon={FaBoxOpen}
+            title="No items in inventory"
+            description="Get started by adding your first inventory item."
+            actionLabel="Add First Item"
+            actionPath="/items/new"
+          />
+        ) : filteredItems.length === 0 ? (
+          <EmptyState
+            icon={FaBoxOpen}
+            title="No items match your filters"
+            description="Try adjusting your search or filter criteria."
+            actionLabel="Clear Filters"
+            onAction={handleResetFilters}
+          />
+        ) : (
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+            totalItems={filteredItems.length}
+            itemsPerPage={ITEMS_PER_PAGE}
+          />
+        )}
       </Card.Body>
 
       <ConfirmModal


### PR DESCRIPTION
## Summary

- Add **Breadcrumbs** component for navigation context on detail/form pages
- Add **EmptyState** component for empty list and no-filter-results states
- Add **Skeleton** loading components with shimmer animation for detail pages
- Organize **ItemForm** into logical fieldsets (Basic Info, Vendor, Inventory, Media)
- Fix button consistency: Delete buttons now use `danger` variant
- Add ARIA labels to icon-only buttons for improved accessibility

## Test plan

- [ ] Verify breadcrumbs appear on ItemDetail, ItemForm, BOMDetail, BOMForm
- [ ] Clear all items and verify EmptyState shows in ItemList
- [ ] Apply filters with no matches and verify EmptyState shows
- [ ] Verify BOMList shows EmptyState when no BOMs exist
- [ ] Load ItemDetail/BOMDetail and verify skeleton animation displays
- [ ] Verify ItemForm sections are visually grouped
- [ ] Verify Delete buttons are red (danger variant)
- [ ] Test icon buttons with screen reader for ARIA labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)