### PR TITLE
Add branch cleanup instruction to create-pr command

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -14,6 +14,7 @@ Create a new branch, commit changes, and submit a pull request.
 - Commits should never include "Co-Authored-By: Claude Opus 4.5
   <noreply@anthropic.com>"
 - PR's should never include "🤖 Generated with Claude Code"
+- After PR creation delete newly created local branch
 
 ## Guidelines for Automatic Commit Splitting
 


### PR DESCRIPTION
## Summary

- Adds instruction to delete the newly created local branch after PR creation
- Helps keep local repository clean by removing feature branches once they're pushed

## Test plan

- [ ] Verify the create-pr command now includes cleanup behavior documentation
- [ ] Confirm the instruction is clear and actionable