### PR TITLE
Update LICENSE copyright year to 2026

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,6 @@
-The MIT License
-===============
+# The MIT License
 
-Copyright (c) 2013-2017 Tony Guntharp
+Copyright (c) 2013-2026 Tony Guntharp
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Updates copyright year from 2013-2017 to 2013-2026
- Converts header to markdown format

## Test plan
- [x] Verify LICENSE.md renders correctly on GitHub